### PR TITLE
Bugfix for SQLite plugin when "SELECT *" is used as a SELECT statement

### DIFF
--- a/l2tscaffolder/__init__.py
+++ b/l2tscaffolder/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """defining the version"""
-__version__ = '20190130'
+__version__ = '20190314'

--- a/l2tscaffolder/scaffolders/plaso_sqlite.py
+++ b/l2tscaffolder/scaffolders/plaso_sqlite.py
@@ -65,6 +65,13 @@ class SQLQuestion(interface.DictQuestion):
               'Unable to run query [{0:s}] with error: {1!s}'.format(
                   query_name, exception))
 
+      star_items = [x for x in query.split() if x == '*']
+      if star_items:
+        raise errors.UnableToConfigure((
+            'Unable to generate parser while using * to select columns. '
+            'Please adjust your SELECT statements to include explicit '
+            'column names.'))
+
 
 class PlasoSQLiteScaffolder(plaso.PlasoPluginScaffolder):
   """The plaso SQLite plugin scaffolder.
@@ -211,6 +218,10 @@ class PlasoSQLiteScaffolder(plaso.PlasoPluginScaffolder):
 
     Yields:
       tuple: file name and content of the file to be written to disk.
+
+    Raises:
+      errors.UnableToConfigure: if it is not possible to generate
+          the files.
     """
     _, _, database_name = self.test_file.rpartition(os.sep)
     self.database_name = database_name
@@ -226,6 +237,10 @@ class PlasoSQLiteScaffolder(plaso.PlasoPluginScaffolder):
       sql_columns[query_name] = []
 
       for column in self._GetQueryColumns(query):
+        if column == '*':
+          raise errors.UnableToConfigure(
+              'Cannot use a "*" as a column name, please select a different '
+              'SELECT statement.')
         if 'time' in column:
           timestamp_columns[query_name].append(column.strip())
         sql_columns[query_name].append(column)

--- a/tests/other/test_version.py
+++ b/tests/other/test_version.py
@@ -12,7 +12,7 @@ class VersionTest(unittest.TestCase):
   def testGetVersion(self):
     """testing the get version"""
     actual = l2tscaffolder.__version__
-    self.assertEqual('20190130', actual)
+    self.assertEqual('20190314', actual)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
SQLite plugins should not have a "SELECT *" statements, the column names that are selected should be explicit.

If you attempt to use "SELECT *" statements while trying to generate a plaso SQLite plugin it will break the tool since it is creating attributes based on the column names from the SELECT statement.

This is a fix for #71 