### PR TITLE
Removing abc for NotImplementedError

### DIFF
--- a/l2tscaffolder/definitions/interface.py
+++ b/l2tscaffolder/definitions/interface.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Interface defining how a project class looks like."""
-import abc
 
 from l2tscaffolder.lib import definitions
 
@@ -9,7 +8,6 @@ class ScaffolderDefinition:
 
   NAME = definitions.DEFINITION_UNDEFINED
 
-  @abc.abstractmethod
   def ValidatePath(self, root_path: str) -> bool:
     """Validates the path to the root directory of the project.
 
@@ -19,3 +17,4 @@ class ScaffolderDefinition:
     Returns:
       bool: whether the given path is the correct root path of the project.
     """
+    raise NotImplementedError

--- a/l2tscaffolder/frontend/output_handler.py
+++ b/l2tscaffolder/frontend/output_handler.py
@@ -55,7 +55,7 @@ class BaseOutputHandler:
     raise NotImplementedError
 
   def PromptError(self, text: str) -> str:
-    """Presents the user with an error message prompt and return back the answer.
+    """Presents the user with an error message prompt and returns the answer.
 
     Args:
       text (str): the text to prompt

--- a/l2tscaffolder/frontend/output_handler.py
+++ b/l2tscaffolder/frontend/output_handler.py
@@ -6,13 +6,11 @@ An output handler is used as a UI element, for two things:
 1. Relay information back to the user.
 2. Gather input from an end user and presenting it back to the tool.
 """
-import abc
 
 
 class BaseOutputHandler:
   """Interface for the output handler."""
 
-  @abc.abstractmethod
   def Confirm(self, text: str, default=True, abort=True):
     """Returns a bool from a yes/no question presented to the end user.
 
@@ -26,36 +24,36 @@ class BaseOutputHandler:
     Returns:
        bool: False if the user entered no, True if the user entered yes
     """
+    raise NotImplementedError
 
-  @abc.abstractmethod
   def PrintError(self, text: str):
     """Presents an error message.
 
     Args:
       text (str): the error message to present.
     """
+    raise NotImplementedError
 
-  @abc.abstractmethod
   def PrintInfo(self, text: str):
     """Presents the user with an informational text.
 
     Args:
       text (str): the text to present.
     """
+    raise NotImplementedError
 
-  @abc.abstractmethod
   def PrintNewLine(self):
     """Adds a new or blank line to the output."""
+    raise NotImplementedError
 
-  @abc.abstractmethod
   def PrintOutput(self, text: str):
     """Presents the user with output from the tool.
 
     Args:
       text (str): the text to present the user with.
     """
+    raise NotImplementedError
 
-  @abc.abstractmethod
   def PromptError(self, text: str) -> str:
     """Presents the user with an error message prompt and return back the answer.
 
@@ -65,8 +63,8 @@ class BaseOutputHandler:
     Returns:
       str: the user input.
     """
+    raise NotImplementedError
 
-  @abc.abstractmethod
   def PromptInfo(self, text: str) -> str:
     """Presents the user with a message prompt and return back the answer.
 
@@ -76,8 +74,8 @@ class BaseOutputHandler:
     Returns:
       str: the user input.
     """
+    raise NotImplementedError
 
-  @abc.abstractmethod
   def PromptInfoWithDefault(
       self, text: str, input_type: type, default: object) -> str:
     """Presents the user with a prompt with a default return value and a type.
@@ -93,3 +91,4 @@ class BaseOutputHandler:
     Returns:
       object: the user input, using the supplied input type.
     """
+    raise NotImplementedError

--- a/l2tscaffolder/scaffolders/interface.py
+++ b/l2tscaffolder/scaffolders/interface.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """The scaffolder interface classes."""
-import abc
-
 from typing import Dict
 from typing import Iterator
 from typing import List
@@ -116,13 +114,13 @@ class Scaffolder:
     super(Scaffolder, self).__init__()
     self._output_name = ''
 
-  @abc.abstractmethod
   def GetInitFileChanges(self) -> Iterator[Tuple[str, str]]:
     """Generate a list of init files that need changing and the changes to them.
 
     Yields:
       tuple (str, str): path to the init file and the entry to add to it.
     """
+    raise NotImplementedError
 
   def GetJinjaContext(self) -> Dict[str, object]:
     """Returns a dict that can be used as a context for Jinja2 templates.
@@ -142,13 +140,13 @@ class Scaffolder:
     """
     return self.QUESTIONS
 
-  @abc.abstractmethod
   def GenerateFiles(self) -> Iterator[Tuple[str, str]]:
     """Generates files this scaffolder provides.
 
     Yields:
       list: file name and content of the file to be written to disk.
     """
+    raise NotImplementedError
 
   def GetFilesToCopy(self) -> Iterator[Tuple[str, str]]:
     """Return a list of files that need to be copied.

--- a/test_data/turbinia_job_output.py
+++ b/test_data/turbinia_job_output.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2019 Google Inc.
+# Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Removing abc for defining abstract methods in interfaces in favor of a more simple NotImplementedError