### PR TITLE
Fixed project directory check for Turbinia

### DIFF
--- a/l2tscaffolder/__init__.py
+++ b/l2tscaffolder/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """defining the version"""
-__version__ = '20190314'
+__version__ = '20200511'

--- a/l2tscaffolder/definitions/turbinia.py
+++ b/l2tscaffolder/definitions/turbinia.py
@@ -28,9 +28,6 @@ class TurbiniaProject(interface.ScaffolderDefinition):
     if not os.path.isdir(os.path.join(root_path, 'turbinia')):
       return False
 
-    if not os.path.isdir(os.path.join(root_path, 'terraform')):
-      return False
-
     if not os.path.isfile(os.path.join(root_path, 'turbinia', 'evidence.py')):
       return False
 

--- a/tests/other/test_version.py
+++ b/tests/other/test_version.py
@@ -12,7 +12,7 @@ class VersionTest(unittest.TestCase):
   def testGetVersion(self):
     """testing the get version"""
     actual = l2tscaffolder.__version__
-    self.assertEqual('20190314', actual)
+    self.assertEqual('20200511', actual)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The 'terraform' directory is not part of the Turbinia base project directory so I removed the check as it kept failing before. 