### PR TITLE
Fixing a small signature mismatch

### DIFF
--- a/l2tscaffolder/frontend/output_handler.py
+++ b/l2tscaffolder/frontend/output_handler.py
@@ -77,7 +77,7 @@ class BaseOutputHandler:
     raise NotImplementedError
 
   def PromptInfoWithDefault(
-      self, text: str, input_type: type, default: object) -> str:
+      self, text: str, input_type: type, default: object) -> object:
     """Presents the user with a prompt with a default return value and a type.
 
     The prompt can have a default value to be chosen as well as a defined type


### PR DESCRIPTION
The function `PromptInfoWithDefault` in the `BaseOutputHandler` class had an return type annotation that was not matching the documented return value type in the comment beneath. Also this resulted in a signature mismatch error with our internal linter since the function is overwritten in the `OutputHandlerClick` class with the correct return value annotation.

Updating the return type annotation for the `PromptInfoWithDefault` in the `BaseOutputHandler` class from `str` to `object` fixes the issue.