### PR TITLE
Updating the timesketch template files

### DIFF
--- a/l2tscaffolder/templates/ts_index_analyzer.jinja2
+++ b/l2tscaffolder/templates/ts_index_analyzer.jinja2
@@ -14,7 +14,7 @@ class {{ class_name }}Plugin(interface.BaseIndexAnalyzer):
         """Initialize the Index Analyzer.
 
         Args:
-            index_name: Elasticsearch index name
+            index_name: Opensearch index name
         """
         super({{ class_name }}Plugin, self).__init__(index_name)
 
@@ -24,7 +24,7 @@ class {{ class_name }}Plugin(interface.BaseIndexAnalyzer):
         Returns:
             String with summary of the analyzer result
         """
-        # TODO: Add Elasticsearch query to get the events you need.
+        # TODO: Add Opensearch query to get the events you need.
         query = ''
 
         # TODO: Specify what returned fields you need for your analyzer.

--- a/l2tscaffolder/templates/ts_index_analyzer_test.jinja2
+++ b/l2tscaffolder/templates/ts_index_analyzer_test.jinja2
@@ -11,14 +11,10 @@ from timesketch.lib.testlib import MockDataStore
 class Test{{ class_name }}Plugin(BaseTest):
     """Tests the functionality of the analyzer."""
 
-    def __init__(self, *args, **kwargs):
-        super(Test{{ class_name }}Plugin, self).__init__(*args, **kwargs)
-
-    # Mock the Elasticsearch datastore.
+    # Mock the Opensearch datastore.
     @mock.patch(
-        u'timesketch.lib.analyzers.interface.ElasticsearchDataStore',
-        MockDataStore)
-    def test_analyzer(self):
-        """Test analyzer."""
+        u'timesketch.lib.analyzers.interface.OpenSearchDataStore', MockDataStore)
+    def test_{{ class_name }}_analyzer_class(self):
+        """Test core functionality of the analyzer class."""
         # TODO: Write actual tests here.
         self.assertEqual(True, False)

--- a/l2tscaffolder/templates/ts_sketch_analyzer.jinja2
+++ b/l2tscaffolder/templates/ts_sketch_analyzer.jinja2
@@ -15,15 +15,15 @@ class {{ class_name }}SketchPlugin(interface.BaseAnalyzer):
 
     DEPENDENCIES = frozenset()
 
-    def __init__(self, index_name, sketch_id):
+    def __init__(self, index_name, sketch_id, timeline_id=None):
         """Initialize The Sketch Analyzer.
 
         Args:
-            index_name: Elasticsearch index name
+            index_name: Opensearch index name
             sketch_id: Sketch ID
         """
         self.index_name = index_name
-        super({{ class_name }}SketchPlugin, self).__init__(index_name, sketch_id)
+        super({{ class_name }}SketchPlugin, self).__init__(index_name, sketch_id, timeline_id=timeline_id)
 
     def run(self):
         """Entry point for the analyzer.
@@ -31,7 +31,7 @@ class {{ class_name }}SketchPlugin(interface.BaseAnalyzer):
         Returns:
             String with summary of the analyzer result
         """
-        # TODO: Add Elasticsearch query to get the events you need.
+        # TODO: Add Opensearch query to get the events you need.
         query = ''
 
         # TODO: Specify what returned fields you need for your analyzer.

--- a/l2tscaffolder/templates/ts_sketch_analyzer_test.jinja2
+++ b/l2tscaffolder/templates/ts_sketch_analyzer_test.jinja2
@@ -11,14 +11,11 @@ from timesketch.lib.testlib import MockDataStore
 class Test{{ class_name }}Plugin(BaseTest):
     """Tests the functionality of the analyzer."""
 
-    def __init__(self, *args, **kwargs):
-        super(Test{{ class_name }}Plugin, self).__init__(*args, **kwargs)
-
-    # Mock the Elasticsearch datastore.
+    # Mock the Opensearch datastore.
     @mock.patch(
-        u'timesketch.lib.analyzers.interface.ElasticsearchDataStore',
+        u'timesketch.lib.analyzers.interface.OpenSearchDataStore',
         MockDataStore)
-    def test_analyzer(self):
-        """Test analyzer."""
+    def test_{{ class_name }}_analyzer_class(self):
+        """Test core functionality of the analyzer class."""
         # TODO: Write actual tests here.
         self.assertEqual(True, False)


### PR DESCRIPTION
Updating the scaffolder templates for timesketch to replace mentions of elasticsearch with the now used opensearch. Further updating the `__init__()` function to not crash the celery worker when running an analyzer by adding the `timeline_id` parameter.